### PR TITLE
Pull the latest image when update

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -12,6 +12,7 @@ const endpoint          = process.env.PLUGIN_ENDPOINT;
 const composeEnvStr     = process.env.PLUGIN_COMPOSE_ENVIRONMENT;
 let   dockerComposeFile = process.env.PLUGIN_COMPOSE_FILE;
 const standalone        = process.env.PLUGIN_STANDALONE;
+const forcePull         = process.env.PLUGIN_FORCE_PULL;
 
 let additionalComposeEnv: { [key: string]: string } = {};
 
@@ -183,7 +184,8 @@ const axios = Axios.create({
                 id: stackToUpdate.Id,
                 StackFileContent: composeFile.toString(),
                 Env: composeEnvArray,
-                Prune: true
+                Prune: true,
+                PullImage: !!forcePull,
             });
 
         if (stackUpdateResponse.status !== 200) {


### PR DESCRIPTION
Hi guys, 

In my workflow, to minimize ECR costs, I choose to overwrite some image tags in some workflows. So, I added this flag to force the redeployment pulling the latest images from repository.

Docs: https://app.swaggerhub.com/apis/portainer/portainer-ce/2.16.2#/stacks/StackUpdate